### PR TITLE
WIP - accept list of object URLs

### DIFF
--- a/gcs-parallel-download/vcpkg.json
+++ b/gcs-parallel-download/vcpkg.json
@@ -9,6 +9,7 @@
     "crc32c",
     "cppcodec",
     "google-cloud-cpp",
+    "boost-coroutine2",
     "boost-endian",
     "boost-program-options",
     "fmt"


### PR DESCRIPTION
WIP -- DO NOT MERGE

This change would modify the usage to accommodate multiple downloads without making the user do any shell scripting. I consider it a step in (hopefully) the right direction, though ultimately it might be better to call list directly, or read a list of objects from stdin, like gsutil cp does (`-I`).

I can think of a few things that need adjustment, too, but before I go polishing, I'd like to get some feedback.

So, one can now initiate multiple downloads with a single command:

`gcs_parallel_download "$(gsutil ls gs://bucket/objectglob*)" /dev/shm`

This lets us "outsource" finding the matching objects to baked and supported gsutil. Also, other commands which give the same newline separated list of URLs would work -- a `bq` query, a `cat` command, etc.

I think the stdin variation might be better for really large transfer lists, and probably can be added in addition to this change. The nice thing is that the original semantic of just giving a single object and a destination is still supported with some minor changes.

Note that supporting multiple download sources also forces a change to the meaning of the `destination` argument. It now must be a directory. This is not currently validated, and it probably should be. Objects are downloaded into the destination directory, with "/" characters replaced with underscores.

There's also a smattering of tweaks to the argument parser error handling and usage printing, nothing major there. I can separate those from this PR, if need be.